### PR TITLE
"get_files()" function now correctly gets the file extension if the file has a "." in the file name

### DIFF
--- a/fs/fileSystem.py
+++ b/fs/fileSystem.py
@@ -61,7 +61,7 @@ def get_files(path: str = "./", extension: bool=True, files_extensions: List[str
     for e in elements:
         if isfile(join(path, e)):
             op = e[e.find(".")+1:]
-            if files_extensions != [] and not e[e.find(".")+1:] in files_extensions:
+            if files_extensions != [] and not e[e.rfind(".")+1:] in files_extensions:
                 continue
             if extension:
                 files.append(e)


### PR DESCRIPTION
This change in "get_files()" function fixes that if you need to get a file with an specific extension, and the file name has a "." (dot) character, select the last "dot" to check the extension. 
Without this modification, "get_files()" used the first "dot" found in the string "e" of the element name to know the file extension and it could cause problems in some cases.